### PR TITLE
feat: SIP Validator and AI Reviewer Bots

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -1,0 +1,72 @@
+name: SIP Reviewer Bot
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/SKILL.md'
+      - 'scripts/sip-validator.js'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run SIP Validator
+        id: validator
+        run: |
+          # Only validate directories that have changed
+          CHANGED_DIRS=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep "SKILL.md" | xargs -I {} dirname {} | sort -u)
+          
+          if [ -z "$CHANGED_DIRS" ]; then
+            echo "No skill changes detected."
+            echo "REPORT=No skills changed." >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          REPORT=""
+          for dir in $CHANGED_DIRS; do
+            echo "Validating $dir..."
+            OUT=$(node scripts/sip-validator.js "$dir") || true
+            REPORT="$REPORT\n$OUT"
+            
+            # Run AI Reviewer
+            echo "Running AI Reviewer on $dir..."
+            AI_OUT=$(node scripts/ai-reviewer.js "$dir") || true
+            if [ -n "$AI_OUT" ]; then
+              REPORT="$REPORT\n\n$AI_OUT"
+            fi
+          done
+          
+          # Clean up for GH output (escape newlines)
+          echo "REPORT<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$REPORT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const report = process.env.REPORT;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "## SIP Validation Results\n" + report
+            })
+        env:
+          REPORT: ${{ steps.validator.outputs.REPORT }}
+

--- a/caveman/SKILL.md
+++ b/caveman/SKILL.md
@@ -11,11 +11,17 @@ composable: true
 yields_to: [process]
 ---
 
+# Caveman Mode — Ultra-Terse Communication
+
+You are a smart caveman. You value tokens like flint. Every extra word is a waste of heat.
+
+## When to Use This Skill
+
 Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 Default: **full**. Switch: `/caveman lite|full|ultra`.
 
-## Rules
+## How It Works
 
 Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
 

--- a/scripts/ai-reviewer.js
+++ b/scripts/ai-reviewer.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const path = require('path');
+
+const target = process.argv[2];
+const apiKey = process.env.GEMINI_API_KEY;
+
+if (!target) {
+    console.error("No target directory specified.");
+    process.exit(1);
+}
+
+if (!apiKey) {
+    console.error("No GEMINI_API_KEY provided. Skipping AI subjective review.");
+    process.exit(0);
+}
+
+const skillName = path.basename(target);
+const skillMdPath = path.join(target, 'SKILL.md');
+
+if (!fs.existsSync(skillMdPath)) {
+    console.error(`Missing SKILL.md in ${skillName}`);
+    process.exit(0);
+}
+
+const content = fs.readFileSync(skillMdPath, 'utf8');
+
+// Optionally, we could load evaluation.md to use as context
+let evaluationContext = "Evaluate the skill based on clarity, edge cases, and composability.";
+const evalPath = path.join(__dirname, '..', 'skill-creator', 'evaluation.md');
+if (fs.existsSync(evalPath)) {
+    evaluationContext = fs.readFileSync(evalPath, 'utf8');
+}
+
+const prompt = `
+You are an expert AI Bot Reviewer for the AntiGravity_Skills repository.
+Your task is to provide a brief, constructive, and highly subjective review of a new or updated skill.
+
+Here are the evaluation rules (SIP ecosystem):
+---
+${evaluationContext.substring(0, 2000)} // Truncated to save tokens if it's very long
+---
+
+Here is the skill content for "${skillName}":
+---
+${content}
+---
+
+Please provide a "Skill Audit" output in Markdown format. Keep it extremely brief (max 3-4 bullet points).
+Rate the skill from 1-10 on Instruction Clarity, Edge Case Handling, and Output Quality.
+Point out any ambiguities or places where the instructions could be more concise.
+Also, suggest 1-2 small, specific changes to improve the skill's structure, clarity, or tone.
+Output only the markdown review.
+`;
+
+async function runReview() {
+    try {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-goog-api-key': apiKey
+            },
+            body: JSON.stringify({
+                contents: [{ parts: [{ text: prompt }] }]
+            })
+        });
+
+        const data = await response.json();
+        
+        if (data.error) {
+            console.error("Gemini API Error:", data.error.message);
+            process.exit(0); // Exit 0 so we don't break CI just because of AI failure
+        }
+
+        const text = data.candidates[0].content.parts[0].text;
+        
+        console.log(`\n## AI Subjective Review for \`${skillName}\``);
+        console.log(text);
+
+    } catch (e) {
+        console.error("Failed to run AI review:", e.message);
+        process.exit(0);
+    }
+}
+
+runReview();

--- a/scripts/sip-validator.js
+++ b/scripts/sip-validator.js
@@ -1,0 +1,141 @@
+const fs = require('fs');
+const path = require('path');
+
+const VALID_DOMAINS = ['voice', 'density', 'craft', 'process', 'content', 'analysis', 'testing'];
+// Use more flexible regex for required sections
+const REQUIRED_SECTIONS = [
+    { name: 'Title', regex: /^#\s.+/m },
+    { name: 'When to Use', regex: /##\s.*(When to Use|Trigger|Triggering)/i },
+    { name: 'How It Works', regex: /##\s.*(How It Works|Instructions|Mechanics|Core Instructions)/i },
+    { name: 'Composability', regex: /##\s.*(Composability|Working With Other Skills|SIP)/i }
+];
+
+function validateSkill(skillPath) {
+    const errors = [];
+    const skillName = path.basename(skillPath);
+    const skillMdPath = path.join(skillPath, 'SKILL.md');
+
+    if (!fs.existsSync(skillMdPath)) {
+        errors.push(`Missing SKILL.md in ${skillName}`);
+        return { name: skillName, errors };
+    }
+
+    const content = fs.readFileSync(skillMdPath, 'utf8');
+    const fmMatch = content.match(/^---\n([\s\S]+?)\n---/);
+
+    if (!fmMatch) {
+        errors.push('Missing or malformed frontmatter (---)');
+    } else {
+        const fmLines = fmMatch[1].split('\n');
+        const fm = {};
+        fmLines.forEach(line => {
+            const parts = line.split(':');
+            if (parts.length >= 2) {
+                const key = parts[0].trim();
+                const val = parts.slice(1).join(':').trim();
+                fm[key] = val;
+            }
+        });
+
+        // Validate required fields
+        if (!fm.name) errors.push('Frontmatter: missing "name"');
+        else if (fm.name !== skillName) errors.push(`Frontmatter: "name" (${fm.name}) does not match folder name (${skillName})`);
+
+        if (!fm.domain) errors.push('Frontmatter: missing "domain"');
+        else {
+            const domains = fm.domain.split('|').map(d => d.trim().replace(/^['">]+|['">]+$/g, ''));
+            const invalid = domains.filter(d => !VALID_DOMAINS.includes(d));
+            if (invalid.length > 0) errors.push(`Frontmatter: invalid domain(s): ${invalid.join(', ')}`);
+        }
+
+        if (fm.composable === undefined) errors.push('Frontmatter: missing "composable"');
+        if (!fm.yields_to) errors.push('Frontmatter: missing "yields_to"');
+    }
+
+    // Size validation
+    const lineCount = content.split('\n').length;
+    let sizeCategory = '';
+    const warnings = [];
+    if (lineCount < 50) {
+        sizeCategory = 'Too Short';
+        warnings.push(`Skill is very short (${lineCount} lines). Ensure instructions are adequately detailed.`);
+    } else if (lineCount <= 150) {
+        sizeCategory = 'Focused';
+    } else if (lineCount <= 350) {
+        sizeCategory = 'Standard';
+    } else if (lineCount <= 500) {
+        sizeCategory = 'Comprehensive';
+    } else {
+        sizeCategory = 'Too Long';
+        errors.push(`Size constraint failed: Skill exceeds 500 lines (${lineCount} lines). Extract content into references/ directory.`);
+    }
+
+    // Header validation
+    REQUIRED_SECTIONS.forEach(section => {
+        if (!section.regex.test(content)) {
+            errors.push(`Content: missing section "${section.name}"`);
+        }
+    });
+
+    return { name: skillName, errors, warnings, sizeCategory, lineCount };
+}
+
+// Main execution
+const target = process.argv[2] || '.';
+const results = [];
+let totalErrors = 0;
+
+if (fs.existsSync(path.join(target, 'SKILL.md'))) {
+    // Target is a single skill folder
+    const res = validateSkill(target);
+    results.push(res);
+    totalErrors += res.errors.length;
+} else {
+    // Target is a directory containing skills
+    const items = fs.readdirSync(target, { withFileTypes: true });
+    items.forEach(item => {
+        if (item.isDirectory() && !item.name.startsWith('.')) {
+            const fullPath = path.join(target, item.name);
+            if (fs.existsSync(path.join(fullPath, 'SKILL.md'))) {
+                const res = validateSkill(fullPath);
+                results.push(res);
+                totalErrors += res.errors.length;
+            }
+        }
+    });
+}
+
+// Output results
+if (process.argv.includes('--json')) {
+    console.log(JSON.stringify({ results, totalErrors }, null, 2));
+} else {
+    console.log('# SIP Validation Report\n');
+    results.forEach(res => {
+        let status = res.errors.length === 0 ? '✅' : '❌';
+        if (res.errors.length === 0 && res.warnings && res.warnings.length > 0) {
+            status = '⚠️';
+        }
+        
+        console.log(`${status} **${res.name}**: ${res.sizeCategory} (${res.lineCount} lines)`);
+        
+        if (res.errors.length > 0) {
+            console.log(`   **Errors (${res.errors.length}):**`);
+            res.errors.forEach(err => console.log(`   - ${err}`));
+        }
+        
+        if (res.warnings && res.warnings.length > 0) {
+            console.log(`   **Warnings (${res.warnings.length}):**`);
+            res.warnings.forEach(warn => console.log(`   - ${warn}`));
+        }
+    });
+
+    if (totalErrors > 0) {
+        console.log(`\n❌ Total errors found: ${totalErrors}`);
+    } else {
+        console.log('\nAll skills passed SIP v1 strict checks.');
+    }
+}
+
+if (totalErrors > 0) {
+    process.exit(1);
+}


### PR DESCRIPTION
This PR introduces two new automation bots for the SIP ecosystem:
1. **SIP Validator** (`scripts/sip-validator.js`): Checks skill structure, mandatory frontmatter, required headings, and enforces size constraints (warns for <50 lines, fails for >500 lines).
2. **AI Reviewer** (`scripts/ai-reviewer.js`): Automatically uses the free Gemini API to review new skills against `evaluation.md` for clarity, tone, edge cases, and provides 1-2 small suggestions.

Both run automatically on pull requests via `.github/workflows/review-bot.yml`.
Also updates `caveman/SKILL.md` to be fully SIP-compliant as a reference.